### PR TITLE
Fix macOS DMG build assets

### DIFF
--- a/scripts/render-dmg-background.swift
+++ b/scripts/render-dmg-background.swift
@@ -1,0 +1,69 @@
+import AppKit
+import Foundation
+
+guard CommandLine.arguments.count == 4,
+      let scale = Int(CommandLine.arguments[3]),
+      scale == 1 || scale == 2 else {
+    fputs("Usage: render-dmg-background.swift <input.svg> <output.png> <1|2>\n", stderr)
+    exit(2)
+}
+
+let sourceURL = URL(fileURLWithPath: CommandLine.arguments[1])
+let outputURL = URL(fileURLWithPath: CommandLine.arguments[2])
+let width = 720
+let height = 390
+
+guard let sourceImage = NSImage(contentsOf: sourceURL) else {
+    fputs("Unable to read DMG background SVG at \(sourceURL.path)\n", stderr)
+    exit(1)
+}
+
+guard let bitmap = NSBitmapImageRep(
+    bitmapDataPlanes: nil,
+    pixelsWide: width * scale,
+    pixelsHigh: height * scale,
+    bitsPerSample: 8,
+    samplesPerPixel: 4,
+    hasAlpha: true,
+    isPlanar: false,
+    colorSpaceName: .deviceRGB,
+    bitmapFormat: [],
+    bytesPerRow: 0,
+    bitsPerPixel: 0
+) else {
+    fputs("Unable to create DMG background bitmap\n", stderr)
+    exit(1)
+}
+
+bitmap.size = NSSize(width: width, height: height)
+
+guard let context = NSGraphicsContext(bitmapImageRep: bitmap) else {
+    fputs("Unable to create DMG background graphics context\n", stderr)
+    exit(1)
+}
+
+NSGraphicsContext.saveGraphicsState()
+NSGraphicsContext.current = context
+context.imageInterpolation = .high
+sourceImage.draw(
+    in: NSRect(x: 0, y: 0, width: width, height: height),
+    from: NSRect(origin: .zero, size: sourceImage.size),
+    operation: .copy,
+    fraction: 1,
+    respectFlipped: true,
+    hints: nil
+)
+context.flushGraphics()
+NSGraphicsContext.restoreGraphicsState()
+
+guard let png = bitmap.representation(using: .png, properties: [:]) else {
+    fputs("Unable to encode DMG background PNG\n", stderr)
+    exit(1)
+}
+
+do {
+    try png.write(to: outputURL, options: .atomic)
+} catch {
+    fputs("Unable to write DMG background PNG: \(error)\n", stderr)
+    exit(1)
+}

--- a/src-tauri/dmg-background.svg
+++ b/src-tauri/dmg-background.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="390" viewBox="0 0 720 390">
+  <rect width="720" height="390" fill="#FBFBFC"/>
+  <text x="360" y="45" fill="#666B73" font-family="-apple-system, BlinkMacSystemFont, 'PingFang SC', sans-serif" font-size="13" font-weight="500" text-anchor="middle">拖动以安装</text>
+  <path d="M314 177H405" fill="none" stroke="#AEB3BA" stroke-width="2" stroke-linecap="round"/>
+  <path d="M397 169L405 177L397 185" fill="none" stroke="#AEB3BA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="360" y="356" fill="#777C84" font-family="-apple-system, BlinkMacSystemFont, 'PingFang SC', sans-serif" font-size="12" font-weight="400" text-anchor="middle">将 RackTop 拖到“应用程序”即可完成安装</text>
+</svg>


### PR DESCRIPTION
补提交 macOS DMG 打包脚本已引用但此前未纳入 Git 的背景 SVG 与渲染器。\n\n本地已验证生成 720×390 与 1440×780 PNG。仅修复 CI 打包依赖，不改变 1.25.2 功能与版本号。