### PR TITLE
v1.25.2 fix: retry temporary DMG detach

### DIFF
--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -52,7 +52,13 @@ RW_DMG_PATH=""
 
 cleanup() {
   if [ -n "$MOUNT_DIR" ] && mount | grep -Fq "on $MOUNT_DIR "; then
-    hdiutil detach "$MOUNT_DIR" >/dev/null || true
+    for attempt in 1 2 3 4 5; do
+      hdiutil detach "$MOUNT_DIR" >/dev/null 2>&1 && break
+      sleep 1
+    done
+    if mount | grep -Fq "on $MOUNT_DIR "; then
+      hdiutil detach "$MOUNT_DIR" -force >/dev/null 2>&1 || true
+    fi
   fi
   case "$STAGE_DIR" in
     /private/tmp/racktop-dmg.*) rm -rf "$STAGE_DIR" ;;
@@ -145,7 +151,15 @@ end run
 APPLESCRIPT
 
 sync
-hdiutil detach "$MOUNT_DIR" >/dev/null
+for attempt in 1 2 3 4 5; do
+  if hdiutil detach "$MOUNT_DIR" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+  if [ "$attempt" = 5 ]; then
+    hdiutil detach "$MOUNT_DIR" -force >/dev/null
+  fi
+done
 MOUNT_DIR=""
 hdiutil convert "$RW_DMG_PATH" -format UDZO -imagekey zlib-level=9 -o "$DMG_PATH" -ov
 rm -f "$RW_DMG_PATH"


### PR DESCRIPTION
修复 macOS CI 在 Finder 仍占用临时 DMG 时因 Resource busy 退出的问题。对脚本自己创建的临时挂载点增加有限重试，最后才使用强制卸载；不改变应用内容或发布版本。